### PR TITLE
Removed "-$style" from EBUILD_COMMAND

### DIFF
--- a/CloverGrowerPro.sh
+++ b/CloverGrowerPro.sh
@@ -655,7 +655,7 @@ function makePKG(){
     fi
 
     # Construct EBUILD_COMMAND
-    EBUILD_COMMAND=("./ebuild.sh" "-${ebuildToolchainFlag}" "-$style")
+    EBUILD_COMMAND=("./ebuild.sh" "-${ebuildToolchainFlag}")
 
     # We can activate VBios Patch in CloverEFI since revision 1162 of Clover
     [[ "$VBIOS_PATCH_IN_CLOVEREFI" -ne 0 && "$versionToBuild" -ge 1162 ]] && \


### PR DESCRIPTION
ebuild.sh no longer takes a -release argument, which unfortunately has broken the CloverGrowerPro script and it no longer works.  The style argument should no longer be passed to ebuild.sh, and it throws an error if passed it now.  Simply omitting it fixes the problem without issue.  For once, it's that easy :).
